### PR TITLE
Allow for automatic source data download.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,138 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+raw :
+	mkdir -p data/raw/
+	. env/ifes/bin/activate; python -m src.download

--- a/README.md
+++ b/README.md
@@ -32,9 +32,37 @@ world. It will use visuals to make those insights available to IFES staff,
 election officials, donors, academics, and the public at
 [electionguide.org](https://www.electionguide.org/).
 
+
+## Get started
+
+See the following resources to learn about the project:
+
 - **GitHub:** https://github.com/DataKind-DC/ifes-elections
 - **Documentation:** Stay tuned.
 - **Application:** Stay tuned.
+
+To install, first clone the repository:
+
+```
+git clone https://github.com/DataKind-DC/ifes-elections
+```
+
+Second, install the project Python package, possibly in a virtual env.
+
+```
+python3 -m venv env/ifes/
+sourced env/ifes/bin/activate
+pip install -e .
+```
+
+Third, put a ``.env`` file in the root directory. This file contains credentials
+for activating the Election Guide API. Ask a data ambassador for access.
+
+Finally, download the raw data to `data/raw/` using `make`:
+
+```
+make raw
+```
 
 
 ## Objective and Outcomes

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Second, install the project Python package, possibly in a virtual env.
 
 ```
 python3 -m venv env/ifes/
-sourced env/ifes/bin/activate
+source env/ifes/bin/activate
 pip install -e .
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,11 @@
+import setuptools
+
+setuptools.setup(
+    name="ifes-elections",
+    version="0.0.0",
+    description="IFES Elections Data Visualization",
+    url="https://github.com/DataKind-DC/ifes-elections",
+    author="DataKind",
+    packages=["src"],
+    zip_safe=False,
+)

--- a/setup.py
+++ b/setup.py
@@ -7,5 +7,9 @@ setuptools.setup(
     url="https://github.com/DataKind-DC/ifes-elections",
     author="DataKind",
     packages=["src"],
+    install_requires=[
+        "python-dotenv>=0.15.0",
+        "requests>=2.25.1",
+    ],
     zip_safe=False,
 )

--- a/src/download.py
+++ b/src/download.py
@@ -1,0 +1,27 @@
+"""Utilities to download raw data"""
+import dotenv
+import os
+import requests
+
+
+def elections():
+    """Download raw election data from the Election Guide API.
+
+    Refer to Election Guide API specifications to understand the data structure
+    and the meaning of specfic fields.
+
+    .. note:: This function requires a ``.env`` file in the project root with
+    the API URL and key. Contact DataKind data ambassadors for access.
+
+    Returns:
+        list: Election data json.
+    """
+    # Load API URL and key.
+    dotenv.load_dotenv()
+    url = os.getenv("URL")
+    key = os.getenv("KEY")
+
+    # Get json from the API.
+    headers = {"Authorization": f"Token {key}"}
+    return requests.get(url, headers=headers).json()
+    

--- a/src/download.py
+++ b/src/download.py
@@ -22,10 +22,16 @@ def elections():
     dotenv.load_dotenv()
     url = os.getenv("URL")
     key = os.getenv("KEY")
-
-    # Get json from the API.
     headers = {"Authorization": f"Token {key}"}
-    return requests.get(url, headers=headers).json()
+
+    # Get json from the API, page by page. Pages have 100 results each.
+    responses = []
+    while url:
+        response = requests.get(url, headers=headers).json()
+        responses.append(response)
+        url = response["next"]
+
+    return responses
 
 
 if __name__ == "__main__":

--- a/src/download.py
+++ b/src/download.py
@@ -1,6 +1,8 @@
 """Utilities to download raw data"""
 import dotenv
+import json
 import os
+import pathlib
 import requests
 
 
@@ -24,4 +26,16 @@ def elections():
     # Get json from the API.
     headers = {"Authorization": f"Token {key}"}
     return requests.get(url, headers=headers).json()
-    
+
+
+if __name__ == "__main__":
+
+    # Path to the raw data.
+    path = pathlib.Path(__file__, "..", "..", "data", "raw").resolve()
+
+    # Get the elections data.
+    data = elections()
+
+    # Write the json to the raw data directory.
+    with open(path / "elections.json", "w+") as f:
+        json.dump(data, f)


### PR DESCRIPTION
Could close #6 . Curious if it could be made friendlier to others' systems.

I figure we could keep the `.env` file on Google Drive to control access to project data somewhat.

This commit includes the following:

- A `src.download` Python module for downloading data.
- A `Makefile` to automate the download.
- A "Get Started" section in the `README.md`.